### PR TITLE
Proxy handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ make test-coverage
  - RequestHandler : Parent to the webserver handlers that defines shared functionality
  - EchoHandler : Echo handling
  - StaticFileHandler : Static file handling
+ - ProxyHandler: Handle requests to a remote host by proxy
 - test : Contains tests for each class
 - build : build files
 
@@ -51,7 +52,7 @@ $ make test-coverage
 - StaticFileHandler : Return static file to client.
 - StatusHandler : Show the webserver status including details of request received and service provide.
 - ErrorHandler : Handle different HTTP errors and show details.
-
+- ProxyHandler : Open a new connection to a remote host and handle requests using new connection.
 
 
 ##Contributors

--- a/src/config_handler.cc
+++ b/src/config_handler.cc
@@ -83,10 +83,10 @@ ConfigHandler::handle_statements(const std::vector<std::shared_ptr<NginxConfigSt
           BOOST_LOG_TRIVIAL(error) << "Illigal duplicate paths";
           return false;
         }
-        if (uri_prefix.back() == '/') {
-          BOOST_LOG_TRIVIAL(error) << "Invalid path name terminated with /";
-          return false;
-        }
+        // if (uri_prefix.back() == '/') {
+        //   BOOST_LOG_TRIVIAL(error) << "Invalid path name terminated with /";
+        //   return false;
+        // }
         check_duplicate_path[uri_prefix] = true;
         if (handler_name == "EchoHandler") {
           config_opt.echo_uri_prefixes.emplace_back(uri_prefix);

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -71,7 +71,7 @@ bool Connection::handle_read_partial(const boost::system::error_code& ec,
         do_read_body(content_length - request.body().length());
         return true;
       }
-      else if (!ProcessRequest(request.uri())) {
+      else if (!ProcessRequest(currRequestUri)) {
         handlers["ErrorHandler"]->HandleRequest(request, &response);
       }
     }

--- a/src/proxy_handler.cc
+++ b/src/proxy_handler.cc
@@ -48,112 +48,112 @@ namespace http{
 	  using boost::asio::ip::tcp;
 	  
   		RequestHandler::Status ProxyHandler::HandleRequest(const Request& request, Response* response){
-  			boost::asio::io_service io_service;
-		    tcp::resolver resolver(io_service);
-		    tcp::resolver::query query(host_name, "http");
-		    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+  			while(true){
+	  			boost::asio::io_service io_service;
+			    tcp::resolver resolver(io_service);
+			    tcp::resolver::query query(host_name, "http");
+			    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 
-		    tcp::socket socket(io_service);
-		    boost::asio::connect(socket, endpoint_iterator);
-		    
-		    std::string uri = request.uri() == uri_prefix ? "/" : request.uri();
+			    tcp::socket socket(io_service);
+			    boost::asio::connect(socket, endpoint_iterator);
+			    
+			    std::string uri = request.uri() == uri_prefix ? "/" : request.uri();
 
-		    //int loc = uri.substr(1).find_first_of("/");
+			    //int loc = uri.substr(1).find_first_of("/");
 
-		    int findLoc = uri.find(uri_prefix);
+			    int findLoc = uri.find(uri_prefix);
 
-		    if(findLoc != -1){
-		    	uri.erase(findLoc, uri_prefix.size());
-		    }
+			    if(findLoc != -1){
+			    	uri.erase(findLoc, uri_prefix.size());
+			    }
 
-		    std::cout << "URIBEINGSENT:  " << uri << std::endl;
- 		    boost::asio::streambuf requestBuf;
-		    std::ostream request_stream(&requestBuf);
-		    request_stream << "GET " << uri << " HTTP/1.1\r\n";
-		    request_stream << "Host: " << host_name << ":" << portno << "\r\n"; 
-		    request_stream << "Accept: */*\r\n";
-		    request_stream << "Connection: close\r\n\r\n";
+			    std::cout << "URIBEINGSENT:  " << uri << std::endl;
+	 		    boost::asio::streambuf requestBuf;
+			    std::ostream request_stream(&requestBuf);
+			    request_stream << "GET " << uri << " HTTP/1.1\r\n";
+			    request_stream << "Host: " << host_name << ":" << portno << "\r\n"; 
+			    request_stream << "Accept: */*\r\n";
+			    request_stream << "Connection: close\r\n\r\n";
 
-		    // Send the request.
-		    boost::asio::write(socket, requestBuf);
+			    // Send the request.
+			    boost::asio::write(socket, requestBuf);
 
-		    // Read the response status line. The response streambuf will automatically
-		    // grow to accommodate the entire line. The growth may be limited by passing
-		    // a maximum size to the streambuf constructor.
-		    boost::asio::streambuf resp;
-		    boost::asio::read_until(socket, resp, "\r\n");
+			    // Read the response status line. The response streambuf will automatically
+			    // grow to accommodate the entire line. The growth may be limited by passing
+			    // a maximum size to the streambuf constructor.
+			    boost::asio::streambuf resp;
+			    boost::asio::read_until(socket, resp, "\r\n");
 
-		    // Check that response is OK.
-		    std::istream response_stream(&resp);
-		    std::string http_version;
-		    response_stream >> http_version;
-		    std::cout << "http version: " << http_version << std::endl;
+			    // Check that response is OK.
+			    std::istream response_stream(&resp);
+			    std::string http_version;
+			    response_stream >> http_version;
+			    std::cout << "http version: " << http_version << std::endl;
 
-		    unsigned int status_code;
-		    response_stream >> status_code;
-		    std::cout << "status code: " << status_code << std::endl;
+			    unsigned int status_code;
+			    response_stream >> status_code;
+			    std::cout << "status code: " << status_code << std::endl;
 
-		    std::string status_message;
-		    std::getline(response_stream, status_message);
-		    std::cout << "status message: " << status_message << std::endl;
-		    
-		    if (!response_stream || http_version.substr(0, 5) != "HTTP/")
-		    {
-		      std::cout << "Invalid response\n";
-		      //return 1;
-		    }
-		    if (status_code == 200)
-		    {
-		      std::cout << "Response returned with status code " << status_code << "\n";
-		      response->SetStatus(Response::ok);
-		      //return 1;
-		    }
-		    else if(status_code == 302 || status_code == 301){
-		      response->SetStatus(Response::redirect);
-		      //return RequestHandler::handle_fail;
-		    }
-		    else if(status_code == 404){
-		      response->SetStatus(Response::not_found);
-		      return RequestHandler::handle_fail;
-		    }
-		    else {
-		      response->SetStatus(Response::bad_request);
-		      return RequestHandler::handle_fail;
-		    }
+			    std::string status_message;
+			    std::getline(response_stream, status_message);
+			    std::cout << "status message: " << status_message << std::endl;
+			    
+			    if (!response_stream || http_version.substr(0, 5) != "HTTP/")
+			    {
+			      std::cout << "Invalid response\n";
+			      //return 1;
+			    }
+			    if (status_code == 200)
+			    {
+			      std::cout << "Response returned with status code " << status_code << "\n";
+			      response->SetStatus(Response::ok);
+			      //return 1;
+			    }
+			    else if(status_code == 404){
+			      response->SetStatus(Response::not_found);
+			      return RequestHandler::handle_fail;
+			    }
+			    else if(status_code == 400){
+			      response->SetStatus(Response::bad_request);
+			      return RequestHandler::handle_fail;
+			    }
 
 
-		    // Read the response headers, which are terminated by a blank line.
-		    boost::asio::read_until(socket, resp, "\r\n\r\n");
+			    // Read the response headers, which are terminated by a blank line.
+			    boost::asio::read_until(socket, resp, "\r\n\r\n");
 
-		    // Process the response headers.
-		    std::string header;
-		    while (std::getline(response_stream, header) && header != "\r"){
-		        std::cout << "response header: " << header << "\n";
-				std::string head = header.substr(0, header.find(":"));
-				std::string value = header.substr(header.find(":")+2);
-				if(head == "Location"){
-					int loc = value.find_last_of("/");
-					value = value.substr(0, loc+1);
-					std::cout << value << std::endl;
-				}
-				std::cout << head << "," << value << std::endl;
-				response->AddHeader(head, value);
-		    }
+			    // Process the response headers.
+			    std::string header;
+			    while (std::getline(response_stream, header) && header != "\r"){
+			        std::cout << "response header: " << header << "\n";
+					std::string head = header.substr(0, header.find(":"));
+					std::string value = header.substr(header.find(":")+2);
+					std::cout << head << "," << value << std::endl;
+					response->AddHeader(head, value);
+					if(status_code==302 && head.compare("Location")==0) {
+	        			host_name = value;
+	        			host_name = host_name.substr(host_name.find(":") +3);
+	        			host_name = host_name.substr(0, host_name.length() - 2);
+	        		}
+			    }
 
-		    // Read until EOF, writing data to output as we go.
-		    boost::system::error_code error;
-		    while (boost::asio::read(socket, resp, error)) {
-		        std::ostringstream ss;
-		        ss << &resp;
-		        response->SetBody(ss.str());
-		        if (error == boost::asio::error::eof) {
-		            break;
-		        }
-		    }
-		    
-		    if (error != boost::asio::error::eof)
-		        std::cout << "Error: " << error << std::endl;
+			    // Read until EOF, writing data to output as we go.
+			    boost::system::error_code error;
+			    while (boost::asio::read(socket, resp, error)) {
+			        std::ostringstream ss;
+			        ss << &resp;
+			        response->SetBody(ss.str());
+			        if (error == boost::asio::error::eof) {
+			            break;
+			        }
+			    }
+			    
+			    if (error != boost::asio::error::eof)
+			        std::cout << "Error: " << error << std::endl;
 
+			    if(status_code != 302 && status_code != 301)
+			    	break;
+			}
 		    return RequestHandler::ok;
   		}
 	}

--- a/src/public_proxy_config_file
+++ b/src/public_proxy_config_file
@@ -9,11 +9,11 @@ server {
 	path /static2 StaticHandler {
 		root content2;
 	}
-	path /proxy1 ProxyHandler {
+	path / ProxyHandler {
 		host www.google.com;
 		port 80;
 	}
-	path / ProxyHandler {
+	path /proxy2 ProxyHandler {
 		host ucla.edu;
 		port 80;
 	}	


### PR DESCRIPTION
Hey the old merge created an issue that stopped our follow-up requests from loading. It was an issue of when you call ProcessRequest(request.uri()) in connection.cc. Can you please double check if everything is okay on your end? Also changed up the redirect to redirect in a proper manner now.